### PR TITLE
Replace "non-breaking space" with regular space

### DIFF
--- a/.atomist/tests/AddRugLanguageExtensionWithANTLRInScala.rt
+++ b/.atomist/tests/AddRugLanguageExtensionWithANTLRInScala.rt
@@ -43,8 +43,8 @@ then
    and fileExists extlang_path
    and fileContains extlang_path { "class " + class_name }
    and fileContains extlang_path { "\"classpath:grammars/antlr/" + grammar_name + ".g4\"" }
-   and fileContains extlang_path { "\""+ grammar_production + "\"" }
-   and fileContains extlang_path { "f.name.endsWith(\""+file_extension+"\")" }
+   and fileContains extlang_path { "\""+ grammar_production + "\"" }
+   and fileContains extlang_path { "f.name.endsWith(\""+file_extension+"\")" }
    and directoryExists test_package_dir
    and fileExists { test_package_dir + "/" + class_name + "Test.scala" }
    and fileContains test_path { "object "+class_name+"Test" }


### PR DESCRIPTION
Fixes 'rug test' failing on Windows 10